### PR TITLE
Save numeric metrics as JSON

### DIFF
--- a/benchmark/compute_metrics.py
+++ b/benchmark/compute_metrics.py
@@ -485,16 +485,17 @@ def compute_metrics(folder, casename=None, show_plot=None, z_axis=None, columns=
             if gt:
                 case["metric"] = compute_metric_set(case["out"]['txyz'], gt['datasets'][0]['data'], metric_set)
 
+                # Save numeric results as JSON.
                 os.makedirs("{}/results".format(folder), exist_ok=True)
-                with open("{}/results/{}.txt".format(folder, name), "w") as f:
-                    # Write results for all benchmarks to info folder
-                    case["out"] = read_out("{}/output/{}.csv".format(folder, name))
-                    f.write("{}: {}\n".format(name, metrics_to_string(case["metric"])))
-                    i = 1
-                    while i < len(gt['datasets']):
-                        metricsString = metrics_to_string(compute_metric_set(gt['datasets'][i]['data'], gt['datasets'][0]['data'], metric_set))
-                        f.write("{}: {}\n".format(gt['datasets'][i]['name'], metricsString))
-                        i += 1
+                with open("{}/results/{}.json".format(folder, name), "w") as f:
+                    jsonResults = { "methods": {} }
+                    jsonResults["methods"]["our"] = case["metric"]
+                    if gt["datasets"]:
+                        jsonResults["groundTruth"] = gt["datasets"][0]["name"]
+                    # Compare other methods against the same ground truth.
+                    for i in range(1, len(gt["datasets"])):
+                        jsonResults["methods"][gt["datasets"][i]["name"]] = compute_metric_set(gt["datasets"][i]["data"], gt["datasets"][0]["data"], metric_set)
+                    json.dump(jsonResults, f, indent=4, sort_keys=True)
 
                 if metricFile:
                     with open(metricFile, "a") as f: f.write("%s,%.9f\n" % (name, average_metric(case["metric"])))


### PR DESCRIPTION
This PR makes `compute_metrics.py` output the following kind of JSON files in the `results/` directory, instead of `txt` files with a vague syntax. The files are per dataset, there are no aggregated results. There is no average of the different metric types included, unlike in the figures, eg: `<avg> -- (<RMSE> | <MAE>)`.

```
{
    "groundTruth": "groundTruth",
    "methods": {
        "our": {
            "100s": 0.06629860324056577,
            "10s": 0.202711444100981,
            "1s": 0.031275149301401406,
            "30s": 0.06629860324056577
        }
    }
}
```
Running with `-metricSet full_3d_align` with multiple methods included in the input JSONL:
```
{
    "groundTruth": "ARKit",
    "methods": {
        "GPS": {
            "MAE": 4.182776422192306,
            "RMSE": 10.05402371729799
        },
        "RTKGPS": {
            "MAE": 1.1741876642745341,
            "RMSE": 1.241954472468604
        },
        "RealSense": {
            "MAE": 4.79510090527546,
            "RMSE": 4.933535873035182
        },
        "our": {
            "MAE": 0.6570144691474284,
            "RMSE": 0.703987706030621
        }
    }
}
```