### PR TITLE
set(CMAKE_BUILD_TYPE RelWithDebInfo)

### DIFF
--- a/basalt_runner/CMakeLists.txt
+++ b/basalt_runner/CMakeLists.txt
@@ -68,7 +68,7 @@ else()
 endif()
 
 if( NOT CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
 if(NOT CXX_MARCH)


### PR DESCRIPTION
Perhaps a more practical default for developing, this gives eg line numbers in debuggers. The `Debug` type defaults aren't usable because Eigen needs at least `-O2` to run at a reasonable speed.