### PR TITLE
Add scripts to calibrate according to Basalt documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /data
+/basalt_runner/download
+/basalt_runner/results
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/basalt_runner/scripts/calibrate_euroc.sh
+++ b/basalt_runner/scripts/calibrate_euroc.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+CAM_TYPE=kb4
+OUT_DIR=results/euroc
+
+target/basalt_calibrate --dataset-path download/euroc/cam_april.bag --dataset-type bag --aprilgrid basalt-mirror/data/aprilgrid_6x6.json --result-path "$OUT_DIR" --cam-types $CAM_TYPE $CAM_TYPE
+
+target/basalt_calibrate_imu \
+  --dataset-path download/euroc/imu_april.bag \
+  --dataset-type bag \
+  --aprilgrid basalt-mirror/data/aprilgrid_6x6.json \
+  --result-path "$OUT_DIR" \
+  --gyro-noise-std 0.000282 \
+  --accel-noise-std 0.016 \
+  --gyro-bias-std 0.0001 \
+  --accel-bias-std 0.001
+
+target/calibration_converter \
+  --calib-path "$OUT_DIR"/calibration.json \
+  --output-path "$OUT_DIR"/calibration_conv.json \

--- a/basalt_runner/scripts/calibrate_euroc.sh
+++ b/basalt_runner/scripts/calibrate_euroc.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Based on <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#euroc-dataset>
 set -euo pipefail
 
 CAM_TYPE=kb4

--- a/basalt_runner/scripts/calibrate_jsonl.sh
+++ b/basalt_runner/scripts/calibrate_jsonl.sh
@@ -12,16 +12,11 @@ target/basalt_calibrate \
   --result-path "$OUT_DIR" \
   --cam-types $CAM_TYPE $CAM_TYPE
 
-# Can the IMU numbers be removed? These are UZH-FPV values from Basalt documentation.
 target/basalt_calibrate_imu \
   --dataset-path "$1" \
   --dataset-type jsonl \
   --aprilgrid "$1"/aprilgrid.json \
-  --result-path "$OUT_DIR" \
-  --gyro-noise-std 0.05 \
-  --accel-noise-std 0.1 \
-  --gyro-bias-std 4e-5 \
-  --accel-bias-std 0.002
+  --result-path "$OUT_DIR"
 
 target/calibration_converter \
   --calib-path "$OUT_DIR"/calibration.json \

--- a/basalt_runner/scripts/calibrate_jsonl.sh
+++ b/basalt_runner/scripts/calibrate_jsonl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+DATA=$1
+CAM_TYPE=kb4
+OUT_DIR=results/jsonl
+
+target/basalt_calibrate \
+  --dataset-path "$1" \
+  --dataset-type jsonl \
+  --aprilgrid "$1"/aprilgrid.json \
+  --result-path "$OUT_DIR" \
+  --cam-types $CAM_TYPE $CAM_TYPE
+
+# Can the IMU numbers be removed? These are UZH-FPV values from Basalt documentation.
+target/basalt_calibrate_imu \
+  --dataset-path "$1" \
+  --dataset-type jsonl \
+  --aprilgrid "$1"/aprilgrid.json \
+  --result-path "$OUT_DIR" \
+  --gyro-noise-std 0.05 \
+  --accel-noise-std 0.1 \
+  --gyro-bias-std 4e-5 \
+  --accel-bias-std 0.002
+
+target/calibration_converter \
+  --calib-path "$OUT_DIR"/calibration.json \
+  --output-path "$OUT_DIR"/calibration_conv.json \

--- a/basalt_runner/scripts/calibrate_uzh.sh
+++ b/basalt_runner/scripts/calibrate_uzh.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Based on <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#uzh-dataset>
 set -euo pipefail
 
 CAM_TYPE=kb4

--- a/basalt_runner/scripts/calibrate_uzh.sh
+++ b/basalt_runner/scripts/calibrate_uzh.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+CAM_TYPE=kb4
+OUT_DIR=results/uzh
+
+target/basalt_calibrate --dataset-path download/uzh/indoor_forward_calib_snapdragon_cam.bag --dataset-type bag --aprilgrid basalt-mirror/data/aprilgrid_5x4_uzh.json --result-path "$OUT_DIR" --cam-types $CAM_TYPE $CAM_TYPE
+
+target/basalt_calibrate_imu \
+  --dataset-path download/uzh/indoor_forward_calib_snapdragon_imu.bag \
+  --dataset-type bag \
+  --aprilgrid basalt-mirror/data/aprilgrid_5x4_uzh.json \
+  --result-path "$OUT_DIR" \
+  --gyro-noise-std 0.05 \
+  --accel-noise-std 0.1 \
+  --gyro-bias-std 4e-5 \
+  --accel-bias-std 0.002
+
+target/calibration_converter \
+  --calib-path "$OUT_DIR"/calibration.json \
+  --output-path "$OUT_DIR"/calibration_conv.json \

--- a/basalt_runner/scripts/setup_euroc.sh
+++ b/basalt_runner/scripts/setup_euroc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#euroc-dataset>
+# Based on <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#euroc-dataset>
 set -euo pipefail
 
 mkdir -p download/euroc

--- a/basalt_runner/scripts/setup_euroc.sh
+++ b/basalt_runner/scripts/setup_euroc.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#euroc-dataset>
+set -euo pipefail
+
+mkdir -p download/euroc
+cd download/euroc
+wget http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/calibration_datasets/cam_april/cam_april.bag
+wget http://robotics.ethz.ch/~asl-datasets/ijrr_euroc_mav_dataset/calibration_datasets/imu_april/imu_april.bag

--- a/basalt_runner/scripts/setup_uzh.sh
+++ b/basalt_runner/scripts/setup_uzh.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#uzh-dataset>
+set -euo pipefail
+
+mkdir -p download/uzh
+cd download/uzh
+wget http://rpg.ifi.uzh.ch/datasets/uzh-fpv/calib/indoor_forward_calib_snapdragon_cam.bag
+wget http://rpg.ifi.uzh.ch/datasets/uzh-fpv/calib/indoor_forward_calib_snapdragon_imu.bag

--- a/basalt_runner/scripts/setup_uzh.sh
+++ b/basalt_runner/scripts/setup_uzh.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#uzh-dataset>
+# Based on <https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md#uzh-dataset>
 set -euo pipefail
 
 mkdir -p download/uzh


### PR DESCRIPTION
This is just the code from https://gitlab.com/VladyslavUsenko/basalt/-/blob/master/doc/Calibration.md

The scripts should be run from the `basalt_runner` directory.

Might be useful for some automation later.